### PR TITLE
Update utils.h to include <limits>

### DIFF
--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -19,8 +19,9 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include "options.h"
+#include <limits>
 
+#include "options.h"
 #include "miniz/miniz.h"
 
 /**

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -201,15 +201,22 @@ inline bool parse_boolstring(const std::string &value) { return value == "true";
 
 inline double double_min() { return std::numeric_limits<double>::min(); }
 
-static inline std::string &ltrim(std::string &s) {
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-  return s;
+// trim from start
+static inline std::string& ltrim(std::string &s)
+{
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch)
+                                    { return !std::isspace(ch); }));
+    return s;
 }
 
 // trim from end
-static inline std::string &rtrim(std::string &s) {
-  s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
-  return s;
+static inline std::string& rtrim(std::string &s)
+{
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch)
+                         { return !std::isspace(ch); })
+                .base(),
+            s.end());
+    return s;
 }
 
 // trim from both ends


### PR DESCRIPTION
GNU 11.3.1 complains about missing <limits> include. This PR fixes it. 
```
 $ make -j1
[  4%] Building CXX object CMakeFiles/cPMML.dir/src/api/exceptions.cc.o
[  9%] Building CXX object CMakeFiles/cPMML.dir/src/api/model.cc.o
In file included from /home/apn/git/cPMML/src/core/closure.h:12,
                 from /home/apn/git/cPMML/src/core/datafield.h:14,
                 from /home/apn/git/cPMML/src/core/datadictionary.h:14,
                 from /home/apn/git/cPMML/src/core/internal_evaluator.h:13,
                 from /home/apn/git/cPMML/src/api/model.cc:8:
/home/apn/git/cPMML/src/utils/utils.h: In function ‘double double_min()’:
/home/apn/git/cPMML/src/utils/utils.h:203:42: error: ‘numeric_limits’ is not a member of ‘std’
  203 | inline double double_min() { return std::numeric_limits<double>::min(); }
      |                                          ^~~~~~~~~~~~~~
/home/apn/git/cPMML/src/utils/utils.h:203:57: error: expected primary-expression before ‘double’
  203 | inline double double_min() { return std::numeric_limits<double>::min(); }
      |                                                         ^~~~~~
/home/apn/git/cPMML/src/utils/utils.h:203:57: error: expected ‘;’ before ‘double’
  203 | inline double double_min() { return std::numeric_limits<double>::min(); }
      |                                                         ^~~~~~
      |                                                         ;
/home/apn/git/cPMML/src/utils/utils.h:203:63: error: expected unqualified-id before ‘>’ token
  203 | inline double double_min() { return std::numeric_limits<double>::min(); }
      |                                                               ^
/home/apn/git/cPMML/src/utils/utils.h: In function ‘std::string format_num(const T&)’:
/home/apn/git/cPMML/src/utils/utils.h:271:29: error: ‘numeric_limits’ is not a member of ‘std’
  271 |   sstr_value.precision(std::numeric_limits<T>::max_digits10);
      |                             ^~~~~~~~~~~~~~
/home/apn/git/cPMML/src/utils/utils.h:271:45: error: expected primary-expression before ‘>’ token
  271 |   sstr_value.precision(std::numeric_limits<T>::max_digits10);
      |                                             ^
/home/apn/git/cPMML/src/utils/utils.h:271:48: error: ‘::max_digits10’ has not been declared
  271 |   sstr_value.precision(std::numeric_limits<T>::max_digits10);
      |                                                ^~~~~~~~~~~~
/home/apn/git/cPMML/src/utils/utils.h: In function ‘std::string format_int(const int&)’:
/home/apn/git/cPMML/src/utils/utils.h:293:29: error: ‘numeric_limits’ is not a member of ‘std’
  293 |   sstr_value.precision(std::numeric_limits<int>::max_digits10);
      |                             ^~~~~~~~~~~~~~
/home/apn/git/cPMML/src/utils/utils.h:293:44: error: expected primary-expression before ‘int’
  293 |   sstr_value.precision(std::numeric_limits<int>::max_digits10);
      |                                            ^~~
^Cmake[2]: *** [CMakeFiles/cPMML.dir/build.make:90: CMakeFiles/cPMML.dir/src/api/model.cc.o] Interrupt
make[1]: *** [CMakeFiles/Makefile2:151: CMakeFiles/cPMML.dir/all] Interrupt
make: *** [Makefile:146: all] Interrupt
```