### PR TITLE
rm std::ptr_fun for gcc12 compliance

### DIFF
--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -201,15 +201,22 @@ inline bool parse_boolstring(const std::string &value) { return value == "true";
 
 inline double double_min() { return std::numeric_limits<double>::min(); }
 
-static inline std::string &ltrim(std::string &s) {
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-  return s;
+// trim from start
+static inline std::string& ltrim(std::string &s)
+{
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch)
+                                    { return !std::isspace(ch); }));
+    return s;
 }
 
 // trim from end
-static inline std::string &rtrim(std::string &s) {
-  s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
-  return s;
+static inline std::string& rtrim(std::string &s)
+{
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch)
+                         { return !std::isspace(ch); })
+                .base(),
+            s.end());
+    return s;
 }
 
 // trim from both ends


### PR DESCRIPTION
This fixes following error (cf. https://stackoverflow.com/a/217605):
```
src/utils/utils.h: In function ‘std::string& ltrim(std::string&)’:
src/utils/utils.h:205:87: error: ‘std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = int; _Result = int]’ is deprecated: use 'std::function' instead [-Werror=deprecated-declarations]
  205 | s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
      |                                                               ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~

[...]

/usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/stl_function.h:1126:5: note: declared here
 1126 |     ptr_fun(_Result (*__x)(_Arg))
      |     ^~~~~~~
src/utils/utils.h: In function ‘std::string& rtrim(std::string&)’:
src/utils/utils.h:211:78: error: ‘std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = int; _Result = int]’ is deprecated: use 'std::function' instead [-Werror=deprecated-declarations]
  211 |   s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
  ```